### PR TITLE
hide jwt secret

### DIFF
--- a/extensions/users-permissions/config/jwt.json
+++ b/extensions/users-permissions/config/jwt.json
@@ -1,3 +1,3 @@
 {
-  "jwtSecret": "4b24a1d7-203c-4a72-97ad-d92c1b144f97"
+  "jwtSecret": "${process.env.JWT_SECRET}"
 }


### PR DESCRIPTION
You shouldn't expose your jwt secrets as it will compromise the security of your app. When launching strapi, you can have an environment variable set in your shell. E.g. `JWT_SECRET=asdkeklfjeklekjflekkjsdlkfjdsfje strapi start`.

https://jwt.io/introduction/
https://www.twilio.com/blog/2017/08/working-with-environment-variables-in-node-js.html